### PR TITLE
chore: update link to Azure OpenAI quickstart docs

### DIFF
--- a/language-model-setup/hosted-models/azure.mdx
+++ b/language-model-setup/hosted-models/azure.mdx
@@ -21,7 +21,7 @@ interpreter.chat()
 
 # Required Environment Variables
 
-Set the following environment variables [(click here to learn how)](https://docs.microsoft.com/en-us/azure/openai/openai-quickstart) to use these models.
+Set the following environment variables [(click here to learn how)](https://learn.microsoft.com/en-us/azure/ai-services/openai/quickstart) to use these models.
 
 | Environment Variable  | Description  | Where to Find  |
 | --------------------- | ------------ | -------------- |


### PR DESCRIPTION
The old link was `404`ing because they moved the docs to this new URL.